### PR TITLE
feat(hitl): M4 frontend — HITL queue page, review modal, WS token auth

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,10 +12,13 @@ import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
 import AnalyticsPage from "./pages/AnalyticsPage";
 import CanvasPage from "./pages/CanvasPage";
 import FlowLibraryPage from "./pages/FlowLibraryPage";
+import HITLQueuePage from "./pages/HITLQueuePage";
 import { useHITLStore } from "./store/hitlStore";
 
 function App(): JSX.Element {
-  const { pendingReviews, startPolling, stopPolling } = useHITLStore();
+  const pendingReviews = useHITLStore((s) => s.pendingReviews);
+  const startPolling = useHITLStore((s) => s.startPolling);
+  const stopPolling = useHITLStore((s) => s.stopPolling);
 
   // Start HITL polling on mount — stop on unmount (Coding Standard 2: no resource leaks)
   useEffect(() => {
@@ -58,6 +61,9 @@ function App(): JSX.Element {
             <Link to="/analytics" style={navLinkStyle}>
               Analytics
             </Link>
+            <Link to="/hitl" style={navLinkStyle}>
+              HITL Queue
+            </Link>
             <span style={{ fontSize: "0.85rem", opacity: 0.7 }}>
               HITL:{" "}
               <strong
@@ -78,6 +84,7 @@ function App(): JSX.Element {
             <Route path="/" element={<FlowLibraryPage />} />
             <Route path="/flows/:id" element={<CanvasPage />} />
             <Route path="/analytics" element={<AnalyticsPage />} />
+            <Route path="/hitl" element={<HITLQueuePage />} />
           </Routes>
         </main>
       </div>

--- a/src/components/hitl/HITLReviewModal.tsx
+++ b/src/components/hitl/HITLReviewModal.tsx
@@ -1,0 +1,254 @@
+/**
+ * HITLReviewModal — three-button decision modal for HITL reviews.
+ *
+ * Three actions:
+ *   Approve     — requires a comment; sends decision:"approved" + comment
+ *   Proceed     — no comment required; sends decision:"approved" + null
+ *   Reject      — requires a comment; sends decision:"rejected" + comment
+ *
+ * Coding Standard 6: split into renderOutput(), HITLCommentSection,
+ * HITLActionBar, and HITLReviewModal so each function stays under 50 lines.
+ * Coding Standard 5: Approve/Reject buttons are disabled (not just guarded)
+ * when comment is empty, giving clear visual feedback before submission.
+ */
+import React, { useState } from "react";
+import type { HITLReview } from "../../types/index";
+
+export interface HITLReviewModalProps {
+  review: HITLReview | null;
+  isOpen: boolean;
+  isSubmitting: boolean;
+  onApprove: (reviewId: string, comment: string) => Promise<void>;
+  onReject: (reviewId: string, comment: string) => Promise<void>;
+  onProceed: (reviewId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+function renderOutput(review: HITLReview): JSX.Element {
+  const raw = review.output_to_review;
+  const outputVal = raw["output"];
+  if (typeof outputVal === "string") {
+    return <p style={{ margin: 0, lineHeight: 1.6 }}>{outputVal}</p>;
+  }
+  // Fallback: always render something — never show empty output
+  return (
+    <pre
+      style={{
+        margin: 0,
+        whiteSpace: "pre-wrap",
+        wordBreak: "break-word",
+        fontSize: "0.8rem",
+      }}
+    >
+      {JSON.stringify(raw, null, 2)}
+    </pre>
+  );
+}
+
+interface HITLCommentSectionProps {
+  comment: string;
+  onChange: (val: string) => void;
+  showError: boolean;
+  disabled: boolean;
+}
+
+function HITLCommentSection(props: HITLCommentSectionProps): JSX.Element {
+  const { comment, onChange, showError, disabled } = props;
+  return (
+    <div>
+      <label
+        style={{ display: "block", fontSize: "0.85rem", marginBottom: "0.4rem" }}
+      >
+        Comments
+      </label>
+      <textarea
+        value={comment}
+        onChange={(e) => onChange(e.target.value)}
+        maxLength={2000}
+        rows={4}
+        disabled={disabled}
+        style={{
+          width: "100%",
+          background: "#0d0d1a",
+          border: "1px solid #0f3460",
+          color: "#e0e0e0",
+          borderRadius: 4,
+          padding: "0.5rem",
+          resize: "vertical",
+          boxSizing: "border-box",
+        }}
+      />
+      {showError && (
+        <p
+          style={{ margin: "0.25rem 0 0", color: "#ff6b6b", fontSize: "0.8rem" }}
+        >
+          Comment is required
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface HITLActionBarProps {
+  commentEmpty: boolean;
+  isSubmitting: boolean;
+  onProceed: () => void;
+  onReject: () => void;
+  onApprove: () => void;
+}
+
+interface HITLModalHeaderProps {
+  reviewId: string;
+  isSubmitting: boolean;
+  onClose: () => void;
+}
+
+function HITLModalHeader({ reviewId, isSubmitting, onClose }: HITLModalHeaderProps): JSX.Element {
+  return (
+    <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+      <h2 style={{ margin: 0, fontSize: "1rem" }}>Review: {reviewId.slice(0, 8)}…</h2>
+      <button onClick={onClose} disabled={isSubmitting} style={closeBtnStyle}>✕</button>
+    </div>
+  );
+}
+
+interface HITLOutputSectionProps {
+  review: HITLReview;
+}
+
+function HITLOutputSection({ review }: HITLOutputSectionProps): JSX.Element {
+  return (
+    <div>
+      <p style={{ margin: "0 0 0.5rem", fontSize: "0.8rem", opacity: 0.6 }}>
+        Agent output
+      </p>
+      <div
+        style={{
+          background: "#0d0d1a",
+          borderRadius: 4,
+          padding: "0.75rem",
+          maxHeight: 200,
+          overflowY: "auto",
+        }}
+      >
+        {renderOutput(review)}
+      </div>
+    </div>
+  );
+}
+
+function HITLActionBar(props: HITLActionBarProps): JSX.Element {
+  const { commentEmpty, isSubmitting, onProceed, onReject, onApprove } = props;
+  return (
+    <div style={{ display: "flex", gap: "0.75rem", justifyContent: "flex-end" }}>
+      <button
+        onClick={onProceed}
+        disabled={isSubmitting}
+        style={{ ...actionBtnStyle, background: "#4dabf7" }}
+      >
+        Proceed as-is
+      </button>
+      <button
+        onClick={onReject}
+        disabled={commentEmpty || isSubmitting}
+        style={{ ...actionBtnStyle, background: "#ff6b6b" }}
+      >
+        Reject
+      </button>
+      <button
+        onClick={onApprove}
+        disabled={commentEmpty || isSubmitting}
+        style={{ ...actionBtnStyle, background: "#69db7c" }}
+      >
+        Approve
+      </button>
+    </div>
+  );
+}
+
+interface HITLModalShellProps {
+  review: HITLReview;
+  isSubmitting: boolean;
+  comment: string;
+  commentEmpty: boolean;
+  showCommentError: boolean;
+  onClose: () => void;
+  onCommentChange: (val: string) => void;
+  onProceed: () => void;
+  onReject: () => void;
+  onApprove: () => void;
+}
+
+function HITLModalShell(props: HITLModalShellProps): JSX.Element {
+  const { review, isSubmitting, comment, commentEmpty, showCommentError } = props;
+  const { onClose, onCommentChange, onProceed, onReject, onApprove } = props;
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "rgba(26,26,46,0.92)", zIndex: 100, display: "flex", alignItems: "center", justifyContent: "center" }}>
+      <div style={{ background: "#16213e", border: "1px solid #0f3460", borderRadius: 8, padding: "1.5rem", width: "min(600px, 90vw)", color: "#e0e0e0", display: "flex", flexDirection: "column", gap: "1rem" }}>
+        <HITLModalHeader reviewId={review.id} isSubmitting={isSubmitting} onClose={onClose} />
+        <HITLOutputSection review={review} />
+        <HITLCommentSection comment={comment} onChange={onCommentChange} showError={showCommentError} disabled={isSubmitting} />
+        <HITLActionBar commentEmpty={commentEmpty} isSubmitting={isSubmitting} onProceed={onProceed} onReject={onReject} onApprove={onApprove} />
+      </div>
+    </div>
+  );
+}
+
+export function HITLReviewModal(props: HITLReviewModalProps): JSX.Element | null {
+  const { review, isOpen, isSubmitting, onApprove, onReject, onProceed, onClose } = props;
+  const [comment, setComment] = useState("");
+  const [showCommentError, setShowCommentError] = useState(false);
+
+  if (!isOpen || review === null) return null;
+
+  const commentEmpty = comment.trim() === "";
+
+  async function handleApproveClick(): Promise<void> {
+    if (commentEmpty) { setShowCommentError(true); return; }
+    setShowCommentError(false);
+    await onApprove(review.id, comment);
+  }
+
+  async function handleRejectClick(): Promise<void> {
+    if (commentEmpty) { setShowCommentError(true); return; }
+    setShowCommentError(false);
+    await onReject(review.id, comment);
+  }
+
+  async function handleProceedClick(): Promise<void> { await onProceed(review.id); }
+
+  return (
+    <HITLModalShell
+      review={review}
+      isSubmitting={isSubmitting}
+      comment={comment}
+      commentEmpty={commentEmpty}
+      showCommentError={showCommentError}
+      onClose={onClose}
+      onCommentChange={setComment}
+      onProceed={() => { void handleProceedClick(); }}
+      onReject={() => { void handleRejectClick(); }}
+      onApprove={() => { void handleApproveClick(); }}
+    />
+  );
+}
+
+const closeBtnStyle: React.CSSProperties = {
+  background: "transparent",
+  border: "none",
+  color: "#e0e0e0",
+  cursor: "pointer",
+  fontSize: "1rem",
+  padding: "0.25rem",
+};
+
+const actionBtnStyle: React.CSSProperties = {
+  border: "none",
+  borderRadius: 4,
+  color: "#1a1a2e",
+  cursor: "pointer",
+  fontWeight: 700,
+  padding: "0.5rem 1.25rem",
+};
+
+export default HITLReviewModal;

--- a/src/hooks/useHitl.ts
+++ b/src/hooks/useHitl.ts
@@ -1,0 +1,49 @@
+/**
+ * useHitl — thin wrapper over useHITLStore for HITL queue pages.
+ *
+ * fetchPending is fire-and-forget (do NOT await it) — errors surface via store.error.
+ * Polling is owned by App.tsx; this hook only performs a one-shot fetch on mount
+ * so the page has data immediately without waiting for the next 5 s poll tick.
+ * reviewed_by is intentionally omitted — no auth context in MVP.
+ *
+ * Coding Standard 6: one hook, one job — delegates all logic to hitlStore.
+ */
+import { useEffect } from "react";
+import type { HITLDecisionRequest, HITLReview } from "../types/index";
+import { useHITLStore } from "../store/hitlStore";
+
+export interface UseHitlResult {
+  pendingReviews: HITLReview[];
+  isLoading: boolean;
+  isSubmitting: boolean;
+  error: string | null;
+  /** Intentional alias for store's fetchPendingReviews(). Fire-and-forget — do NOT await. */
+  fetchPending: () => void;
+  submitDecision: (reviewId: string, payload: HITLDecisionRequest) => Promise<void>;
+}
+
+export function useHitl(): UseHitlResult {
+  const pendingReviews = useHITLStore((s) => s.pendingReviews);
+  const isLoading = useHITLStore((s) => s.isLoading);
+  const isSubmitting = useHITLStore((s) => s.isSubmitting);
+  const error = useHITLStore((s) => s.error);
+  const fetchPendingReviews = useHITLStore((s) => s.fetchPendingReviews);
+  const submitDecisionStore = useHITLStore((s) => s.submitDecision);
+
+  // One-shot fetch on mount — [] is intentional; polling is already running in App.tsx.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { fetchPendingReviews(); }, []);
+
+  function fetchPending(): void {
+    fetchPendingReviews();
+  }
+
+  function submitDecision(
+    reviewId: string,
+    payload: HITLDecisionRequest
+  ): Promise<void> {
+    return submitDecisionStore(reviewId, payload);
+  }
+
+  return { pendingReviews, isLoading, isSubmitting, error, fetchPending, submitDecision };
+}

--- a/src/pages/HITLQueuePage.tsx
+++ b/src/pages/HITLQueuePage.tsx
@@ -1,0 +1,150 @@
+/**
+ * HITLQueuePage — lists pending HITL reviews at route /hitl.
+ *
+ * FE-13, FE-14: uses useHitl hook; owns selectedReview state.
+ * Initial data fetch is triggered by useHitl's internal useEffect.
+ * Polling is owned by App.tsx — this page does NOT start/stop polling.
+ * reviewed_by is intentionally omitted in all payloads — no auth context in MVP.
+ *
+ * Coding Standard 6: one component, one job — table rendering extracted to HITLReviewTable.
+ * Coding Standard 5: all submitDecision calls wrapped in try/catch.
+ */
+import React, { useState } from "react";
+import { HITLReviewModal } from "../components/hitl/HITLReviewModal";
+import { useHitl } from "../hooks/useHitl";
+import type { HITLDecisionRequest, HITLReview } from "../types/index";
+
+// ─── HITLReviewTable ──────────────────────────────────────────────────────────
+
+interface HITLReviewTableProps {
+  pendingReviews: HITLReview[];
+  onReview: (review: HITLReview) => void;
+}
+
+function HITLReviewTable({ pendingReviews, onReview }: HITLReviewTableProps): JSX.Element {
+  return (
+    <table style={{ width: "100%", borderCollapse: "collapse", fontSize: "0.9rem" }}>
+      <thead>
+        <tr style={{ background: "#1a1a2e", textAlign: "left" }}>
+          {["Review ID", "Agent ID", "Gate Type", "Created At", "Action"].map((h) => (
+            <th key={h} style={thStyle}>{h}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {pendingReviews.map((review) => (
+          <tr
+            key={review.id}
+            style={{ background: "#16213e", borderBottom: "1px solid #0f3460" }}
+          >
+            <td style={tdStyle}>{review.id.slice(0, 8)}…</td>
+            <td style={tdStyle}>
+              {review.agent_id !== null ? review.agent_id.slice(0, 8) + "…" : "—"}
+            </td>
+            <td style={tdStyle}>{review.gate_type}</td>
+            <td style={tdStyle}>{new Date(review.created_at).toLocaleString()}</td>
+            <td style={tdStyle}>
+              <button onClick={() => onReview(review)} style={reviewBtnStyle}>
+                Review
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+// ─── HITLQueuePage ────────────────────────────────────────────────────────────
+
+function HITLQueuePage(): JSX.Element {
+  const { pendingReviews, isLoading, isSubmitting, error, submitDecision } = useHitl();
+  const [selectedReview, setSelectedReview] = useState<HITLReview | null>(null);
+
+  async function handleApprove(reviewId: string, comment: string): Promise<void> {
+    const payload: HITLDecisionRequest = { decision: "approved", reviewer_comments: comment };
+    try {
+      await submitDecision(reviewId, payload);
+      setSelectedReview(null);
+    } catch {
+      // error already set in store — displayed below heading
+    }
+  }
+
+  async function handleReject(reviewId: string, comment: string): Promise<void> {
+    const payload: HITLDecisionRequest = { decision: "rejected", reviewer_comments: comment };
+    try {
+      await submitDecision(reviewId, payload);
+      setSelectedReview(null);
+    } catch {
+      // error already set in store
+    }
+  }
+
+  async function handleProceed(reviewId: string): Promise<void> {
+    const payload: HITLDecisionRequest = { decision: "approved", reviewer_comments: null };
+    try {
+      await submitDecision(reviewId, payload);
+      setSelectedReview(null);
+    } catch {
+      // error already set in store
+    }
+  }
+
+  return (
+    <div style={{ padding: "2rem", color: "#e0e0e0" }}>
+      <h1 style={{ fontSize: "1.5rem", marginBottom: "0.5rem" }}>HITL Review Queue</h1>
+
+      {error !== null && (
+        <p style={{ color: "#ff6b6b", marginBottom: "1rem" }}>{error}</p>
+      )}
+
+      {isLoading && pendingReviews.length === 0 && (
+        <p style={{ opacity: 0.5 }}>Loading reviews…</p>
+      )}
+
+      {!isLoading && pendingReviews.length === 0 && (
+        <p style={{ opacity: 0.5 }}>No pending reviews</p>
+      )}
+
+      {pendingReviews.length > 0 && (
+        <HITLReviewTable
+          pendingReviews={pendingReviews}
+          onReview={setSelectedReview}
+        />
+      )}
+
+      <HITLReviewModal
+        review={selectedReview}
+        isOpen={selectedReview !== null}
+        isSubmitting={isSubmitting}
+        onApprove={handleApprove}
+        onReject={handleReject}
+        onProceed={handleProceed}
+        onClose={() => setSelectedReview(null)}
+      />
+    </div>
+  );
+}
+
+// ─── Style constants ──────────────────────────────────────────────────────────
+
+const thStyle: React.CSSProperties = {
+  padding: "0.6rem 1rem",
+  fontWeight: 600,
+  opacity: 0.7,
+};
+
+const tdStyle: React.CSSProperties = { padding: "0.6rem 1rem" };
+
+const reviewBtnStyle: React.CSSProperties = {
+  background: "#4dabf7",
+  border: "none",
+  borderRadius: 4,
+  color: "#1a1a2e",
+  cursor: "pointer",
+  fontWeight: 700,
+  padding: "0.3rem 0.9rem",
+};
+
+export default HITLQueuePage;

--- a/src/services/wsClient.ts
+++ b/src/services/wsClient.ts
@@ -2,7 +2,7 @@
  * ExecutionWSClient — native browser WebSocket wrapper for execution events.
  *
  * No library required — uses the browser's built-in WebSocket API.
- * Reconnects up to MAX_RECONNECT_ATTEMPTS times with exponential backoff.
+ * Reconnects up to MAX_RECONNECT_ATTEMPTS times with linear backoff.
  *
  * Coding Standard 2: reconnect timer is always cleared on deliberate disconnect.
  * Coding Standard 8: external WS events are validated before being forwarded.
@@ -12,6 +12,14 @@ import type { WSEvent } from "../types";
 const WS_BASE =
   (import.meta.env.VITE_WS_BASE_URL as string | undefined) ??
   "ws://localhost:8000";
+
+// API key for WS auth — same env var as apiClient (see #29 S-04 for BFF plan).
+// Cast to `string | undefined` first so the nullish coalescing fallback fires
+// when the env var is absent (bare `as string` silently produces "undefined").
+// An empty string triggers a 4001 close immediately — the guard in onclose
+// handles that path without retrying.
+const WS_API_KEY =
+  (import.meta.env.VITE_API_KEY as string | undefined) ?? "";
 
 const MAX_RECONNECT_ATTEMPTS = 3;
 const RECONNECT_BASE_DELAY_MS = 2_000;
@@ -41,7 +49,7 @@ export class ExecutionWSClient {
     if (!this.executionId) return;
 
     this.ws = new WebSocket(
-      `${WS_BASE}/ws/executions/${this.executionId}`
+      `${WS_BASE}/ws/executions/${this.executionId}?token=${encodeURIComponent(WS_API_KEY)}`
     );
 
     this.ws.onmessage = (event: MessageEvent) => {
@@ -61,7 +69,16 @@ export class ExecutionWSClient {
       }
     };
 
-    this.ws.onclose = () => {
+    this.ws.onclose = (event: CloseEvent) => {
+      if (event.code === 4001) {
+        // Auth failure — cancel pending reconnect and signal close without retrying
+        if (this.reconnectTimer !== null) {
+          clearTimeout(this.reconnectTimer);
+          this.reconnectTimer = null;
+        }
+        this.onCloseCallback?.();
+        return;
+      }
       if (this.reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
         this.reconnectAttempts++;
         const delay = RECONNECT_BASE_DELAY_MS * this.reconnectAttempts;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -169,6 +169,8 @@ export type WSEventType =
   | "step_completed"
   | "step_failed"
   | "hitl_required"
+  | "hitl_review_pending"
+  | "hitl_review_decided"
   | "execution_completed"
   | "execution_failed";
 


### PR DESCRIPTION
## Summary

- **`types/index.ts`**: extended `WSEventType` with `hitl_review_pending` and `hitl_review_decided`
- **`wsClient.ts`**: append `?token=${encodeURIComponent(WS_API_KEY)}` to WS URL; no-retry on close code 4001 (auth failure)
- **`useHitl` hook** (`hooks/useHitl.ts`): thin Zustand wrapper; one-shot `useEffect` fetch on mount; polling exclusively owned by `App.tsx`
- **`HITLReviewModal`** (`components/hitl/HITLReviewModal.tsx`): three-button decision UI — Approve and Reject require a comment; Proceed as-is bypasses comment; split into 6 sub-components for Coding Standard 6 (50-line limit)
- **`HITLQueuePage`** (`pages/HITLQueuePage.tsx`): `/hitl` route, pending review table, try/catch handlers constructing correct `HITLDecisionRequest` payloads; optimistic removal via store
- **`App.tsx`**: `/hitl` route added; "HITL Queue" nav link between Analytics and badge

## Issues closed

- #FE-13 HITL queue page: list pending reviews
- #FE-14 HITL review modal: show output, approve/reject
- #S-06 WebSocket token-in-query-param auth (frontend side)

## Test plan

- [ ] Navigate to `/hitl` — shows "No pending reviews" or table if reviews exist
- [ ] Click "Review" on a row — modal opens with agent output and comment field
- [ ] Click Approve/Reject with empty comment — inline error shown, buttons stay disabled
- [ ] Fill comment and Approve — row disappears from table
- [ ] Click "Proceed as-is" — works without comment
- [ ] WS DevTools: confirm `?token=` in WS upgrade request URL
- [ ] Kill WS with code 4001 — no reconnect attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)