### PR TITLE
feat(analytics): M5 AnalyticsService + endpoints [#BC-11 #BA-11]

### DIFF
--- a/backend/app/api/analytics.py
+++ b/backend/app/api/analytics.py
@@ -1,0 +1,68 @@
+"""
+Analytics router — BA-11 (agent stats endpoints).
+
+Thin router: validate path param → call AnalyticsService → return response.
+No SQL queries here (ARCHITECTURE.md layer rule: no business logic in routers).
+
+Security:
+- verify_api_key on every route (SECURITY.md)
+- No LLM calls — rate limiting not required for this router
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.dependencies import get_db, verify_api_key
+from app.schemas.analytics import AgentAnalyticsListResponse, AgentAnalyticsSummary
+from app.services.analytics_service import AnalyticsService
+
+router = APIRouter(tags=["analytics"])
+
+# Stateless singleton — no instance state; safe to share across requests
+_analytics_service = AnalyticsService()
+
+
+@router.get(
+    "/agents",
+    response_model=AgentAnalyticsListResponse,
+    summary="List aggregated stats for all agents",
+    dependencies=[Depends(verify_api_key)],
+)
+async def list_agent_stats(
+    db: AsyncSession = Depends(get_db),
+) -> AgentAnalyticsListResponse:
+    """
+    Return execution statistics for every agent that has been executed at least once.
+
+    Results are sorted alphabetically by agent name.
+    Returns an empty list (not 404) when no analytics data exists yet.
+    """
+    summaries = await _analytics_service.get_all_agents_stats(db=db)
+    return AgentAnalyticsListResponse(items=summaries, total=len(summaries))
+
+
+@router.get(
+    "/agents/{agent_id}",
+    response_model=AgentAnalyticsSummary,
+    summary="Get aggregated stats for a single agent",
+    dependencies=[Depends(verify_api_key)],
+)
+async def get_agent_stats(
+    agent_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> AgentAnalyticsSummary:
+    """
+    Return execution statistics for a single agent.
+
+    Returns 404 if the agent has no analytics record (never executed or does not exist).
+    """
+    summary = await _analytics_service.get_agent_stats(db=db, agent_id=agent_id)
+    if summary is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No analytics found for the specified agent",
+        )
+    return summary

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -26,6 +26,7 @@ from app.api.agents import router as agents_router
 from app.api.executions import router as executions_router
 from app.api.flows import router as flows_router
 from app.api.health import router as health_router
+from app.api.analytics import router as analytics_router
 from app.api.hitl import router as hitl_router
 from app.api.memory import router as memory_router
 from app.api.models import router as models_router
@@ -91,6 +92,9 @@ def create_app() -> FastAPI:
 
     # HITL review endpoints — BA-07 / BA-08
     app.include_router(hitl_router, prefix="/api/v1")
+
+    # Analytics endpoints — BA-11 / BC-11
+    app.include_router(analytics_router, prefix="/api/v1/analytics")
 
     # LLM model discovery — returns available models from the Dial proxy
     # No auth required — frontend uses this to populate the model picker

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -18,7 +18,11 @@ from app.schemas.execution import (
     StepExecutionResponse,
 )
 from app.schemas.hitl import HITLDecisionRequest, HITLReviewResponse
-from app.schemas.analytics import AgentAnalyticsResponse
+from app.schemas.analytics import (
+    AgentAnalyticsListResponse,
+    AgentAnalyticsResponse,
+    AgentAnalyticsSummary,
+)
 from app.schemas.memory import FlowMemoryResponse, FlowMemoryUpdateRequest
 
 __all__ = [
@@ -34,6 +38,8 @@ __all__ = [
     "HITLDecisionRequest",
     "HITLReviewResponse",
     "AgentAnalyticsResponse",
+    "AgentAnalyticsSummary",
+    "AgentAnalyticsListResponse",
     "FlowMemoryResponse",
     "FlowMemoryUpdateRequest",
 ]

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -1,18 +1,25 @@
 """
-Pydantic v2 response schema for AgentAnalytics.
+Pydantic v2 response schemas for analytics endpoints (BA-11).
 
-Read-only — the analytics table is written exclusively by the DB trigger.
-avg_execution_time_ms is a float because the DB stores DECIMAL(10,2).
+AgentAnalyticsResponse: legacy per-agent row schema (unchanged).
+AgentAnalyticsSummary: M5 summary schema used by the analytics router.
+AgentAnalyticsListResponse: list wrapper for GET /analytics/agents.
+
+Read-only — the agent_analytics table is written exclusively by the
+sync_agent_analytics PostgreSQL trigger (docs/architecture/DATABASE.md).
+Coding Standard 3: all fields explicitly typed.
 """
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class AgentAnalyticsResponse(BaseModel):
+    """Legacy schema — kept for backwards compat with existing imports."""
     id: UUID
     agent_id: UUID
     total_runs: int
@@ -25,4 +32,35 @@ class AgentAnalyticsResponse(BaseModel):
     total_hitl_reviews: int
     last_run_at: Optional[str]
 
-    model_config = {"from_attributes": True}
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentAnalyticsSummary(BaseModel):
+    """
+    Aggregated execution stats for a single agent — used by GET /analytics/agents.
+
+    success_rate is computed by AnalyticsService (0.0 when total_executions == 0).
+    avg_execution_time_ms and last_executed_at are None when the agent has
+    never been executed.
+    """
+
+    agent_id: UUID
+    agent_name: str
+    total_executions: int
+    successful_executions: int
+    failed_executions: int
+    # Computed field — not stored in DB; derived in AnalyticsService
+    success_rate: float
+    # None until at least one execution has completed
+    avg_execution_time_ms: Optional[float]
+    last_executed_at: Optional[datetime]
+
+    # from_attributes=True: allows construction from SQLAlchemy row objects
+    model_config = ConfigDict(from_attributes=True)
+
+
+class AgentAnalyticsListResponse(BaseModel):
+    """Response wrapper for GET /analytics/agents."""
+
+    items: list[AgentAnalyticsSummary]
+    total: int

--- a/backend/app/services/analytics_service.py
+++ b/backend/app/services/analytics_service.py
@@ -1,0 +1,118 @@
+"""
+AnalyticsService — read-only queries over agent_analytics (BA-11 / BC-11).
+
+The agent_analytics table is populated exclusively by the sync_agent_analytics
+PostgreSQL trigger (docs/architecture/DATABASE.md). This service NEVER inserts
+or updates that table — doing so would corrupt the trigger-managed aggregates.
+
+Coding Standard 2: async session ownership stays with the caller (get_db).
+Coding Standard 3: explicit return types and parameter types throughout.
+Coding Standard 6: guard clauses; max 50 lines per method.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.agent import Agent
+from app.models.agent_analytics import AgentAnalytics
+from app.schemas.analytics import AgentAnalyticsSummary
+
+logger = logging.getLogger(__name__)
+
+
+def _compute_success_rate(total: int, successful: int) -> float:
+    """Return successful / total, or 0.0 when total is zero (guard: no ZeroDivision)."""
+    if total <= 0:
+        return 0.0
+    return round(successful / total, 4)
+
+
+def _row_to_summary(agent_name: str, aa: AgentAnalytics) -> AgentAnalyticsSummary:
+    """
+    Map an AgentAnalytics ORM row + agent name to the response schema.
+
+    avg_execution_time_ms is stored as DECIMAL(10,2); cast to float for JSON.
+    last_run_at maps to last_executed_at in the response schema.
+    """
+    # Explicit None check — falsy check would coerce 0.0 (valid value) to None
+    avg_ms: Optional[float] = (
+        float(aa.avg_execution_time_ms) if aa.avg_execution_time_ms is not None else None
+    )
+    # last_run_at is Mapped[Optional[object]] in the ORM model (SQLAlchemy DateTime
+    # maps to datetime at runtime; declared as object to avoid cross-dialect import
+    # issues). The isinstance check is safe: the DateTime column always returns a
+    # datetime instance or None from the DB driver.
+    last_run: Optional[datetime] = aa.last_run_at if isinstance(aa.last_run_at, datetime) else None
+    return AgentAnalyticsSummary(
+        agent_id=aa.agent_id,
+        agent_name=agent_name,
+        total_executions=aa.total_runs,
+        successful_executions=aa.successful_runs,
+        failed_executions=aa.failed_runs,
+        success_rate=_compute_success_rate(aa.total_runs, aa.successful_runs),
+        avg_execution_time_ms=avg_ms,
+        last_executed_at=last_run,
+    )
+
+
+class AnalyticsService:
+    """
+    Read-only analytics queries.
+
+    Stateless — safe to instantiate once and reuse across requests.
+    All methods accept a caller-provided AsyncSession so the session
+    lifecycle is owned by the FastAPI dependency (get_db).
+    """
+
+    async def get_all_agents_stats(
+        self,
+        db: AsyncSession,
+    ) -> list[AgentAnalyticsSummary]:
+        """
+        Return aggregated stats for every agent that has an analytics row.
+
+        JOIN agent_analytics → agents to get the human-readable agent name.
+        Results are sorted alphabetically by agent name for stable UI ordering.
+        Returns an empty list when no analytics rows exist.
+        """
+        stmt = (
+            sa.select(Agent.name, AgentAnalytics)
+            .join(Agent, Agent.id == AgentAnalytics.agent_id)
+            .order_by(Agent.name.asc())
+        )
+        result = await db.execute(stmt)
+        rows = result.all()
+
+        return [_row_to_summary(agent_name=str(name), aa=aa) for name, aa in rows]
+
+    async def get_agent_stats(
+        self,
+        db: AsyncSession,
+        agent_id: UUID,
+    ) -> Optional[AgentAnalyticsSummary]:
+        """
+        Return aggregated stats for a single agent, or None if not found.
+
+        Returns None (not HTTP 404) — the router translates None to 404.
+        Architecture rule: no HTTP concerns in service layer.
+        """
+        stmt = (
+            sa.select(Agent.name, AgentAnalytics)
+            .join(Agent, Agent.id == AgentAnalytics.agent_id)
+            .where(AgentAnalytics.agent_id == agent_id)
+        )
+        result = await db.execute(stmt)
+        row = result.first()
+
+        if row is None:
+            return None
+
+        agent_name: str = str(row[0])
+        aa: AgentAnalytics = row[1]
+        return _row_to_summary(agent_name=agent_name, aa=aa)


### PR DESCRIPTION
## Summary
- Adds AnalyticsService with get_all_agents_stats and get_agent_stats read-only queries over the trigger-managed agent_analytics table
- Adds GET /api/v1/analytics/agents and GET /api/v1/analytics/agents/{agent_id} endpoints with verify_api_key auth
- Adds AgentAnalyticsSummary and AgentAnalyticsListResponse Pydantic schemas
- success_rate computed in service (0.0 default when no executions); agent_analytics table never written by app code

## Issues closed
- Closes #BC-11 AnalyticsService
- Closes #BA-11 Analytics API endpoints

## Test plan
- [ ] GET /api/v1/analytics/agents returns { items: [], total: 0 } when no executions have run
- [ ] GET /api/v1/analytics/agents/{agent_id} returns 404 for unknown agent
- [ ] Both endpoints return 401 without X-API-Key header
- [ ] success_rate is 0.0 when total_executions is 0 (no division by zero)

## Checklist
- [ ] No hardcoded secrets
- [ ] Follows all 10 coding standards
- [ ] Type hints complete
- [ ] CHANGELOG.md updated

Generated with Claude Code
Session: 2026-04-10